### PR TITLE
Update Base.php

### DIFF
--- a/lib/Rails/WillPaginate/Renderer/Base.php
+++ b/lib/Rails/WillPaginate/Renderer/Base.php
@@ -27,13 +27,13 @@ abstract class Base
     
     public function toHtml()
     {
-        $html = implode(array_map(function($item){
+        $html = implode($this->options['linkSeparator'], array_map(function($item){
             if (is_int($item)) {
                 return $this->pageNumber($item);
             } else {
                 return $this->$item();
             }
-        }, $this->pagination()), $this->options['linkSeparator']);
+        }, $this->pagination()));
         
         return $this->options['container'] ? $this->htmlContainer($html) : $html;
     }


### PR DESCRIPTION
Updated order of implode() parameters to support PHP 7.4+; change should be backwards compatible until at least PHP 5.6