### PR TITLE
Update Bootstraps

### DIFF
--- a/lib/Rails/WillPaginate/Renderer/Bootstrap2.php
+++ b/lib/Rails/WillPaginate/Renderer/Bootstrap2.php
@@ -5,13 +5,13 @@ class Bootstrap2 extends Base
 {
     public function toHtml()
     {
-        $html = implode(array_map(function($item){
+        $html = implode($this->options['linkSeparator'], array_map(function($item){
             if (is_int($item)) {
                 return $this->pageNumber($item);
             } else {
                 return $this->$item();
             }
-        }, $this->pagination()), $this->options['linkSeparator']);
+        }, $this->pagination()));
         
         return $this->htmlContainer($this->tag('ul', $html));
     }

--- a/lib/Rails/WillPaginate/Renderer/Bootstrap3.php
+++ b/lib/Rails/WillPaginate/Renderer/Bootstrap3.php
@@ -5,13 +5,13 @@ class Bootstrap3 extends Base
 {
     public function toHtml()
     {
-        $html = implode(array_map(function($item){
+        $html = implode($this->options['linkSeparator'], array_map(function($item){
             if (is_int($item)) {
                 return $this->pageNumber($item);
             } else {
                 return $this->$item();
             }
-        }, $this->pagination()), $this->options['linkSeparator']);
+        }, $this->pagination()));
         
         return $this->htmlContainer($html);
     }


### PR DESCRIPTION
Apologies, but it appears the same order error in operations that was in Base.php is also present in Bootstrap2.php and Bootstrap3.php. These are minor changes, so there should be no need to change the v1.0.1 label for them as it's the same fix as what v1.0.1 was for.